### PR TITLE
Fix nil Err handling and zap context encoding errors

### DIFF
--- a/errs.go
+++ b/errs.go
@@ -141,12 +141,18 @@ func (e *Error) Error() string {
 	if e == nil {
 		return nilAngleString
 	}
-	errMsg := e.Err.Error()
+	var errMsg string
+	if e.Err != nil {
+		errMsg = e.Err.Error()
+	}
 	var causeMsg string
 	if e.Cause != nil {
 		causeMsg = e.Cause.Error()
 	}
 	if len(causeMsg) == 0 {
+		if len(errMsg) == 0 {
+			return nilAngleString
+		}
 		return errMsg
 	}
 	if len(errMsg) == 0 {

--- a/errs_test.go
+++ b/errs_test.go
@@ -447,6 +447,26 @@ func TestUnwraps(t *testing.T) {
 	}
 }
 
+func TestErrorWithNilErr(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  *Error
+		want string
+	}{
+		{name: "empty", err: &Error{}, want: "<nil>"},
+		{name: "cause only", err: &Error{Cause: os.ErrInvalid}, want: "invalid argument"},
+		{name: "err and cause", err: &Error{Err: os.ErrNotExist, Cause: os.ErrInvalid}, want: "file does not exist: invalid argument"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 /* Copyright 2019-2023 Spiegel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/zapobject/zapobject.go
+++ b/zapobject/zapobject.go
@@ -45,7 +45,9 @@ func (e ErrObject) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 			sort.Strings(keys)
 			enc.OpenNamespace("context")
 			for _, k := range keys {
-				_ = enc.AddReflected(k, ee.Context[k])
+				if err := enc.AddReflected(k, ee.Context[k]); err != nil {
+					return err
+				}
 			}
 		}
 	} else {

--- a/zapobject/zapobject_test.go
+++ b/zapobject/zapobject_test.go
@@ -1,0 +1,26 @@
+package zapobject
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/goark/errs"
+	"go.uber.org/zap/zapcore"
+)
+
+type addReflectedErrEncoder struct {
+	*zapcore.MapObjectEncoder
+}
+
+func (e *addReflectedErrEncoder) AddReflected(_ string, _ interface{}) error {
+	return errors.New("add reflected failed")
+}
+
+func TestMarshalLogObject_AddReflectedError(t *testing.T) {
+	err := errs.New("wrapped", errs.WithContext("bad", func() {}))
+	enc := &addReflectedErrEncoder{MapObjectEncoder: zapcore.NewMapObjectEncoder()}
+
+	if got := New(err).MarshalLogObject(enc); got == nil {
+		t.Fatal("MarshalLogObject() = nil, want non-nil error")
+	}
+}


### PR DESCRIPTION
## Summary
- guard `(*errs.Error).Error()` against `Err == nil` to avoid panic
- keep string formatting behavior consistent when only cause is present
- propagate `AddReflected` errors in `zapobject.ErrObject.MarshalLogObject` instead of ignoring them
- add regression tests for both behaviors

## Validation
- `go test -shuffle on ./...`
- `go test -shuffle on ./zapobject/...`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`

All passed locally.